### PR TITLE
GitHub Action: Documentation

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install needed dependencies
         run: |
-          sudo apt update && sudo apt install -y texlive texinfo make
+          sudo apt update && sudo apt install -y texlive-full texinfo ghostscript make
       - name: Build the documentation
         run: |
           ls -la && cd Documentation && make

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -16,4 +16,4 @@ jobs:
           sudo apt update && sudo apt install -y texlive texinfo make
       - name: Build the documentation
         run: |
-          cd Documentation && make
+          ls -la && cd Documentation && make

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,6 +11,8 @@ jobs:
   documentation:
     runs-on: ubuntu-20.04
     steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
       - name: Install needed dependencies
         run: |
           sudo apt update && sudo apt install -y texlive texinfo make

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -10,12 +10,13 @@ on:
 jobs:
   documentation:
     runs-on: ubuntu-20.04
+    container: texlive/texlive
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
       - name: Install needed dependencies
         run: |
-          sudo apt update && sudo apt install -y texlive-full texinfo ghostscript make
+          sudo apt update && sudo apt install -y texinfo
       - name: Build the documentation
         run: |
-          ls -la && cd Documentation && make
+          cd Documentation && make

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install needed dependencies
         run: |
-          sudo apt update && sudo apt install -y texinfo
+          apt update && apt install -y texinfo
       - name: Build the documentation
         run: |
           cd Documentation && make

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -2,10 +2,10 @@ name: Documentation
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, synchronize]
+    branches: [main]
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   documentation:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,19 @@
+name: Documentation
+
+on:
+  pull_request:
+    types: [opened, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  documentation:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install needed dependencies
+        run: |
+          apt update && apt install -y texlive texinfo make
+      - name: Build the documentation
+        run: |
+          cd Documentation && make

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Install needed dependencies
         run: |
-          apt update && apt install -y texlive texinfo make
+          sudo apt update && sudo apt install -y texlive texinfo make
       - name: Build the documentation
         run: |
           cd Documentation && make


### PR DESCRIPTION
Implemented a Continuous Integration check in the repository that:
- Creates a Ubuntu 20.04 VM with a Docker Container running 'texinfo/texinfo' image
- Installs Documentation Build Dependencies (TeX Live, GNU Texinfo, GNU Make)
- Builds the documentation (Makefile)

when:
- A PR is opened
- A PR is reopened
- Push to main is made