### PR TITLE
Documentation: saving workflow artifact

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,10 +13,16 @@ jobs:
     container: texlive/texlive
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
-      - name: Install needed dependencies
+        uses: actions/checkout@v3
+      - name: Install GNU Texinfo support
         run: |
           apt update && apt install -y texinfo
       - name: Build the documentation
         run: |
           cd Documentation && make
+      - name: Archive Documentation Manual
+        uses: actions/upload-artifact@v3
+        with:
+          name: Metal Birlant GDD (preview)
+          path: Documentation/metal-birlant-gdd-*.pdf
+          retention-days: 7

--- a/HACKING
+++ b/HACKING
@@ -1,0 +1,22 @@
+How to externally contribute to the project?
+---------------------------------
+1. Fork the repository.
+2. Start adding commits to the project.
+3. Open a PR in draft mode (put a checklist in the description with all tasks to be made).
+4. When wanting to integrate the changes to upstream, mark the PR as ready for review.
+5. Wait for the feedback.
+
+
+How to make a release request?
+------------------------------
+1. Define new version depending on the type of changes made (major, patch, maintenance).
+2. Set this new version in the Makefile.
+3. Update the NEWS & ChangeLog files with information of the new version:
+  - NEWS: Deep explanation of the news that come with this new release in a non-technical way.
+  - ChangeLog: Log (list-like) of all the technical changes been made to the code.
+4. Encapsulate this changes in a commit named "Metal Birlant vX.X.X". If the SUBLEVEL number (or maintenance level) of the version is 0 (usual thing during git development), it can be ommitted and the commit will end up being "Metal Birlant vX.X".
+5. Create a tag for this last commit with this specs:
+  - Name: vX.X.X
+  - Comment: "Metal Birlant vX.X.X" or "Metal Birlant vX.X" (the same as in the commit).
+6. Push the changes (with tags) to your branch's remote (git push --tags).
+7. Create a PR to request merging the release to the main branch.


### PR DESCRIPTION
Now the workflow saves the generated GDD PDF to an artifact for 7 days (acceptable retention period).
So, each time the workflow runs, in addition to checking if the documentation compiles or not, also saves the generated PDF.
This saves the need to create inconsequential releases or tags for each relevant documentation version.

PD: Also added the last project's standard metadata file ('HACKING'), with instructions to developers and/or collaborators.